### PR TITLE
伴播面板 UX v4 - 商品列表3.5行 + 特殊动作默认空 + 时间轴分区

### DIFF
--- a/zhuboaixia-clone/src/CanvasPanel.tsx
+++ b/zhuboaixia-clone/src/CanvasPanel.tsx
@@ -314,15 +314,78 @@ function getStepCompletion(products: ProductItem[], selectedProductId: string | 
 // ============ Timeline 左栏组件（深色风格） ============
 function TimelineLeftBar({
   products, selectedProductId, onSelectProduct, banboEnabled, onToggleBanbo,
+  previewStateId, setPreviewStateId, previewEventId, setPreviewEventId,
 }: {
   products: ProductItem[]; selectedProductId: string | null;
   onSelectProduct: (id: string) => void; banboEnabled: boolean; onToggleBanbo: () => void;
+  previewStateId: string | null; setPreviewStateId: (id: string | null) => void;
+  previewEventId: string | null; setPreviewEventId: (id: string | null) => void;
 }) {
   const totalDuration = 60 // 60秒时间轴
   const productItemRefs = useRef<Record<string, HTMLDivElement | null>>({})
   const previewCardRefs = useRef<Record<string, HTMLDivElement | null>>({})
   const productListRef = useRef<HTMLDivElement>(null)
   const previewAreaRef = useRef<HTMLDivElement>(null)
+  const autoPlayTimerRef = useRef<ReturnType<typeof setInterval> | null>(null)
+
+  // 自动轮播逻辑：banboEnabled 时随机选中常态片段
+  useEffect(() => {
+    if (!banboEnabled || !selectedProductId) {
+      if (autoPlayTimerRef.current) { clearInterval(autoPlayTimerRef.current); autoPlayTimerRef.current = null }
+      return
+    }
+    const product = products.find(p => p.id === selectedProductId)
+    if (!product?.boundAvatarId) return
+    const states = NORMAL_STATES[product.boundAvatarId] || DEFAULT_STATES
+    if (states.length === 0) return
+    // 立即随机选一个
+    const pick = () => {
+      const idx = Math.floor(Math.random() * states.length)
+      setPreviewStateId(states[idx].id)
+      setPreviewEventId(null)
+    }
+    pick()
+    const avgDuration = states.reduce((s, st) => s + st.duration, 0) / states.length
+    autoPlayTimerRef.current = setInterval(pick, avgDuration * 1000)
+    return () => { if (autoPlayTimerRef.current) { clearInterval(autoPlayTimerRef.current); autoPlayTimerRef.current = null } }
+  }, [banboEnabled, selectedProductId])
+
+  // 手动点击时间轴块
+  const handleTimelineBlockClick = (stateId: string) => {
+    // 停止自动轮播（用户手动控制）
+    if (autoPlayTimerRef.current) { clearInterval(autoPlayTimerRef.current); autoPlayTimerRef.current = null }
+    setPreviewStateId(stateId)
+    setPreviewEventId(null)
+  }
+
+  // 手动点击事件块
+  const handleEventBlockClick = (eventId: string) => {
+    if (autoPlayTimerRef.current) { clearInterval(autoPlayTimerRef.current); autoPlayTimerRef.current = null }
+    setPreviewEventId(eventId)
+    setPreviewStateId(null)
+    // 事件播放一次后自动恢复轮播
+    const product = products.find(p => p.id === selectedProductId)
+    if (!product?.boundAvatarId) return
+    const eventActions = EVENT_ACTIONS[product.boundAvatarId] || DEFAULT_EVENT_ACTIONS
+    const ev = eventActions.find(e => e.id === eventId)
+    if (!ev) return
+    setTimeout(() => {
+      setPreviewEventId(null)
+      // 恢复自动轮播
+      if (banboEnabled) {
+        const states = NORMAL_STATES[product.boundAvatarId!] || DEFAULT_STATES
+        if (states.length > 0) {
+          const pick = () => {
+            const idx = Math.floor(Math.random() * states.length)
+            setPreviewStateId(states[idx].id)
+          }
+          pick()
+          const avgDuration = states.reduce((s, st) => s + st.duration, 0) / states.length
+          autoPlayTimerRef.current = setInterval(pick, avgDuration * 1000)
+        }
+      }
+    }, ev.duration * 1000)
+  }
 
   // 点击商品 → 滚动对应预览卡片到可见区域 + 选中项滚动到可见
   const handleSelectProduct = (id: string) => {
@@ -479,71 +542,88 @@ function TimelineLeftBar({
                     </div>
                   </div>
 
-                  {/* 时间轴条 */}
+                  {/* 分区时间轴 */}
                   <div style={{ marginTop: 4 }}>
                     <div style={{
                       display: 'flex', alignItems: 'center', gap: 4, marginBottom: 3,
                     }}>
-                      <span style={{ fontSize: 9, color: '#60A5FA', fontWeight: 500 }}>直播中（自动轮播）</span>
+                      <span style={{ fontSize: 9, color: '#60A5FA', fontWeight: 500 }}>
+                        {previewEventId ? '🎬 事件播放中' : '直播中（自动轮播）'}
+                      </span>
                       <span style={{ fontSize: 9, color: 'rgba(255,255,255,0.4)' }}>{normalDuration}s 循环</span>
                     </div>
-                    {/* 时间标注 */}
+                    {/* 常态分区块：按动作切分，可点击 */}
                     <div style={{
-                      display: 'flex', justifyContent: 'space-between',
-                      marginBottom: 2, padding: '0 1px',
+                      display: 'flex', gap: 2, height: 20, borderRadius: 4,
+                      overflow: 'hidden',
                     }}>
-                      {['0s', '15s', '30s', '45s', '60s'].map(t => (
-                        <span key={t} style={{ fontSize: 7, color: 'rgba(255,255,255,0.3)' }}>{t}</span>
-                      ))}
-                    </div>
-                    <div style={{
-                      height: 8, borderRadius: 4,
-                      background: 'rgba(255,255,255,0.08)',
-                      overflow: 'hidden', position: 'relative',
-                    }}>
-                      {Array.from({ length: Math.ceil(totalDuration / normalDuration) }).map((_, i) => (
-                        <div key={i} style={{
-                          position: 'absolute',
-                          left: `${(i * normalDuration / totalDuration) * 100}%`,
-                          width: `${(normalDuration / totalDuration) * 100}%`,
-                          height: '100%',
-                          background: i % 2 === 0 ? 'rgba(96,165,250,0.6)' : 'rgba(96,165,250,0.3)',
-                          borderRadius: 2,
-                          display: 'flex', alignItems: 'center', justifyContent: 'center',
-                        }}>
-                          {i === 0 && <span style={{ fontSize: 6, color: 'rgba(255,255,255,0.7)', fontWeight: 600 }}>轮播</span>}
-                        </div>
-                      ))}
+                      {normalStates.map(st => {
+                        const isActive = previewStateId === st.id && !previewEventId
+                        const isDimmed = previewEventId !== null // 事件态播放时默认态变暗
+                        return (
+                          <div key={st.id} onClick={() => handleTimelineBlockClick(st.id)} style={{
+                            flex: st.duration,
+                            height: '100%',
+                            borderRadius: 2,
+                            cursor: 'pointer',
+                            display: 'flex', alignItems: 'center', justifyContent: 'center',
+                            gap: 2,
+                            background: isActive
+                              ? 'rgba(96,165,250,0.7)'
+                              : 'rgba(96,165,250,0.15)',
+                            opacity: isDimmed ? 0.3 : 1,
+                            boxShadow: isActive ? '0 0 6px rgba(96,165,250,0.5)' : 'none',
+                            transition: 'all 0.2s',
+                            border: '1px solid rgba(255,255,255,0.06)',
+                          }}>
+                            <span style={{ fontSize: 8 }}>{st.icon}</span>
+                            <span style={{
+                              fontSize: 7, color: isActive ? '#fff' : 'rgba(255,255,255,0.6)',
+                              fontWeight: isActive ? 600 : 400,
+                              overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+                            }}>{st.label}</span>
+                          </div>
+                        )
+                      })}
                     </div>
 
+                    {/* 事件态分区块 */}
                     {eventActions.length > 0 && (
                       <>
                         <div style={{
-                          display: 'flex', alignItems: 'center', gap: 4, marginTop: 4,
+                          display: 'flex', alignItems: 'center', gap: 4, marginTop: 6, marginBottom: 3,
                         }}>
-                          <span style={{ fontSize: 9, color: '#F59E0B', fontWeight: 500 }}>口令触发</span>
-                          <span style={{ fontSize: 9, color: 'rgba(255,255,255,0.4)' }}>{eventDuration}s 触发</span>
+                          <span style={{ fontSize: 9, color: '#F59E0B', fontWeight: 500 }}>⚡ 口令触发（点击播放）</span>
                         </div>
                         <div style={{
-                          height: 8, borderRadius: 4,
-                          background: 'rgba(255,255,255,0.08)',
-                          overflow: 'hidden', position: 'relative',
-                          marginTop: 2,
+                          display: 'flex', gap: 2, height: 18, borderRadius: 4,
+                          overflow: 'hidden',
                         }}>
-                          <div style={{
-                            position: 'absolute',
-                            left: '10%', width: `${(eventDuration / totalDuration) * 100}%`,
-                            height: '100%',
-                            background: 'rgba(245,158,11,0.6)',
-                            borderRadius: 2,
-                            display: 'flex', alignItems: 'center', justifyContent: 'center',
-                          }}>
-                            <span style={{ fontSize: 6, color: 'rgba(255,255,255,0.8)', fontWeight: 600 }}>触发</span>
-                          </div>
-                          <span style={{
-                            position: 'absolute', left: '3%', top: -1,
-                            fontSize: 7, color: 'rgba(255,255,255,0.5)',
-                          }}>触发点 ▸</span>
+                          {eventActions.map(ev => {
+                            const isActive = previewEventId === ev.id
+                            return (
+                              <div key={ev.id} onClick={() => handleEventBlockClick(ev.id)} style={{
+                                flex: ev.duration,
+                                height: '100%',
+                                borderRadius: 2,
+                                cursor: 'pointer',
+                                display: 'flex', alignItems: 'center', justifyContent: 'center',
+                                gap: 2,
+                                background: isActive
+                                  ? 'rgba(245,158,11,0.7)'
+                                  : 'rgba(245,158,11,0.15)',
+                                boxShadow: isActive ? '0 0 6px rgba(245,158,11,0.5)' : 'none',
+                                transition: 'all 0.2s',
+                                border: '1px solid rgba(255,255,255,0.06)',
+                              }}>
+                                <span style={{ fontSize: 7 }}>🎬</span>
+                                <span style={{
+                                  fontSize: 7, color: isActive ? '#fff' : 'rgba(255,255,255,0.6)',
+                                  fontWeight: isActive ? 600 : 400,
+                                }}>{ev.label}</span>
+                              </div>
+                            )
+                          })}
                         </div>
                       </>
                     )}
@@ -2797,6 +2877,10 @@ export default function CanvasPanel({ onClose }: Props) {
             }}
             banboEnabled={banboEnabled}
             onToggleBanbo={() => setBanboEnabled(!banboEnabled)}
+            previewStateId={previewStateId}
+            setPreviewStateId={setPreviewStateId}
+            previewEventId={previewEventId}
+            setPreviewEventId={setPreviewEventId}
           />
 
           {/* 右侧：统一配置面板 */}

--- a/zhuboaixia-clone/src/CanvasPanel.tsx
+++ b/zhuboaixia-clone/src/CanvasPanel.tsx
@@ -367,12 +367,12 @@ function TimelineLeftBar({
         </div>
       </div>
 
-      {/* 商品完成度列表 */}
+      {/* 商品完成度列表（精确3.5行：每行26px × 3.5 + gap 2px × 3 = 97px） */}
       <div ref={productListRef} style={{
         padding: '6px 8px', flexShrink: 0,
         borderBottom: '1px solid rgba(255,255,255,0.08)',
         background: 'rgba(0,0,0,0.15)',
-        maxHeight: 120, overflowY: 'auto',
+        maxHeight: 97, overflowY: 'auto',
       }}>
         <div style={{ fontSize: 9, color: 'rgba(255,255,255,0.4)', marginBottom: 4, padding: '0 4px' }}>商品配置</div>
         <div style={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
@@ -387,7 +387,7 @@ function TimelineLeftBar({
             return (
               <div key={p.id} ref={el => { productItemRefs.current[p.id] = el }} onClick={() => handleSelectProduct(p.id)} style={{
                 display: 'flex', alignItems: 'center', gap: 6,
-                padding: '4px 8px', borderRadius: 4,
+                padding: '4px 8px', borderRadius: 4, height: 26, flexShrink: 0,
                 background: isSelected ? 'rgba(96,165,250,0.15)' : 'transparent',
                 border: isSelected ? '1px solid rgba(96,165,250,0.3)' : '1px solid transparent',
                 cursor: 'pointer', transition: 'all 0.15s',
@@ -1423,11 +1423,11 @@ function UnifiedBanboPanel({
               ) : localEventActions.length > 0 ? (
                 <div>
                   <div style={{ fontSize: 10, color: C.textSec, marginBottom: 8, lineHeight: 1.5 }}>
-                    ⚡ 以下是该模特支持的特殊动作，开启后主播说对应口令就会触发
+                    ⚡ 该模特支持以下特殊动作，点击开关启用后配置触发口令
                   </div>
                   <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
                     {localEventActions.map(ev => {
-                      const isEnabled = enabledActions[ev.id] !== false // 默认开启
+                      const isEnabled = enabledActions[ev.id] === true // 默认关闭，用户手动开启
                       const isEditing = editingEventId === ev.id
                       return (
                         <div key={ev.id} style={{
@@ -1491,6 +1491,13 @@ function UnifiedBanboPanel({
                         </div>
                       )
                     })}
+                  </div>
+                  <div style={{
+                    fontSize: 9, color: C.textSec, marginTop: 8, padding: '6px 8px',
+                    background: '#F0F4FF', borderRadius: 6, lineHeight: 1.5,
+                    border: '1px solid rgba(96,165,250,0.15)',
+                  }}>
+                    💡 口令采用模糊匹配：主播原样念出或简单改几个字都能触发，但字数改动过大时大概率匹配失败，建议用简短易记的口令
                   </div>
                 </div>
               ) : (


### PR DESCRIPTION
Closes #9

## 改动内容

### 1. 商品列表精确3.5行
- maxHeight 120→97px，每行固定26px
- 视觉效果：3行完整 + 第4行露出约13px（一半）

### 2. 特殊动作默认关闭
- enabledActions 默认全部 OFF，用户手动开启
- 新增口令模糊匹配引导说明（蓝色提示条）
- 引导文案更新：强调「点击开关启用」

### 3. 分区按键式时间轴
- 连续进度条 → 按动作切分的可点击区块
- 常态：6个区块按 duration 比例分配宽度
- 自动轮播：useEffect + setInterval 随机选块高亮
- 手动点击：直接播放对应片段
- 事件态：独立行，点击播放一次后恢复轮播
- 事件播放时默认态变暗（覆盖效果）

## 测试
- [ ] 商品列表展示3.5行视觉效果
- [ ] Step3 特殊动作默认关闭
- [ ] 时间轴区块可点击+高亮联动
- [ ] 部署到 miaobo-b.pages.dev