### PR TITLE
fix: 缩略图网格适配 9:16 素材

### DIFF
--- a/zhuboaixia-clone/src/CanvasPanel.tsx
+++ b/zhuboaixia-clone/src/CanvasPanel.tsx
@@ -865,7 +865,7 @@ function ProductAvatarContent({
                           background: '#f0f0f0', marginBottom: 4,
                         }}>
                           <ChromaKeyImage src={av.preview} alt={av.name}
-                            style={{ width: '100%', height: '100%', objectFit: 'cover' }} draggable={false} />
+                            style={{ width: '100%', height: '100%', objectFit: 'contain' }} draggable={false} />
                         </div>
                         <div style={{ fontSize: 9, fontWeight: 600, color: C.text }}>{av.name}</div>
                         {isCurrent && <div style={{ fontSize: 8, color: C.green, marginTop: 1 }}>✅ 当前</div>}
@@ -909,7 +909,7 @@ function ProductAvatarContent({
                         background: '#f0f0f0', marginBottom: 3,
                       }}>
                         <ChromaKeyImage src={av.preview} alt={av.name}
-                          style={{ width: '100%', height: '100%', objectFit: 'cover' }} draggable={false} />
+                          style={{ width: '100%', height: '100%', objectFit: 'contain' }} draggable={false} />
                       </div>
                       <div style={{ fontSize: 9, fontWeight: 600, color: C.text }}>{av.name}</div>
                     </div>
@@ -1406,7 +1406,7 @@ function UnifiedBanboPanel({
                         </div>
                         <div style={{ width: '100%', aspectRatio: '1', borderRadius: 6, overflow: 'hidden', background: '#f0f0f0', marginBottom: 4 }}>
                           <ChromaKeyImage src={av.preview} alt={av.name}
-                            style={{ width: '100%', height: '100%', objectFit: 'cover' }} draggable={false} />
+                            style={{ width: '100%', height: '100%', objectFit: 'contain' }} draggable={false} />
                         </div>
                         <div style={{ fontSize: 10, fontWeight: 600, color: C.text }}>{av.name}</div>
                       </div>


### PR DESCRIPTION
Closes #13

## 改动
- 3 处形象库网格缩略图 objectFit: cover → contain
- 9:16 竖屏素材在方形缩略图框内不再被上下裁切
- 主预览区和详情预览区本身已是 9:16 + contain，无需修改

## 测试
- 缩略图网格：9:16 图片完整展示（带左右留白）
- 主预览区：视频/图片 9:16 比例正确
- 部署到 miaobo-b.pages.dev 验收